### PR TITLE
Remove victims' code and witness charter links from footer

### DIFF
--- a/vis/templates/includes/_footer.jade
+++ b/vis/templates/includes/_footer.jade
@@ -13,10 +13,6 @@ footer.SiteFooter(role="contentinfo")
           ul.SiteFooter-nav
             li.SiteFooter-navItem
               a(href="{% slugurl 'glossary' %}") Find the meaning of a legal term
-            li.SiteFooter-navItem
-              a(href="https://www.gov.uk/government/publications/the-code-of-practice-for-victims-of-crime") Download the Victims' Code
-            li.SiteFooter-navItem
-              a(href="https://www.gov.uk/government/publications/the-witness-charter-standards-of-care-for-witnesses-in-the-criminal-justice-system") Download the Witness Charter
       .SiteFooter-aside
         p.SiteFooter-copyright
           a(href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright/crown-copyright/") &copy; Crown copyright


### PR DESCRIPTION
No longer needed in footer as will be added elsewhere within the content