### PR TITLE
Merge in CloudFormation/CSRF/Zendesk changes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - heroku config:add GIT_SHA=$CIRCLE_SHA1 --app vis-staging
       - heroku config:add DEPLOY_DATETIME=`date -Is` --app vis-staging
       - heroku run python manage.py migrate --noinput --app vis-staging
-      - '[ $(curl -s -o /dev/null -w "%{http_code}" https://vis-staging.herokuapp.com/healthcheck.json) = 200 ]'
+      - '[ $(curl -s -o /dev/null -w "%{http_code}" https://origin-staging.victimsinformationservice.org.uk/healthcheck.json) = 200 ]'
   production:
     branch: master
     commands:
@@ -46,4 +46,4 @@ deployment:
       - heroku config:add GIT_SHA=$CIRCLE_SHA1 --app vis-prod
       - heroku config:add DEPLOY_DATETIME=`date -Is` --app vis-prod
       - heroku run python manage.py migrate --noinput --app vis-prod
-      - '[ $(curl -s -o /dev/null -w "%{http_code}" https://www.victimsinformationservice.org.uk/healthcheck.json) = 200 ]'
+      - '[ $(curl -s -o /dev/null -w "%{http_code}" https://origin.victimsinformationservice.org.uk/healthcheck.json) = 200 ]'

--- a/vis/apps/zendesk/views.py
+++ b/vis/apps/zendesk/views.py
@@ -3,6 +3,8 @@
 from django.http import JsonResponse
 from django.http.response import Http404
 from django.shortcuts import redirect
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.vary import vary_on_headers
 from django.views.generic.base import View
 from wagtail.wagtailcore.models import Page
@@ -16,6 +18,10 @@ def get_user_agent_from_request(request):
     return request.META.get('HTTP_USER_AGENT')
 
 class ZendeskView(View):
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        super(ZendeskView, self).dispatch(*args, **kwargs)
 
     @vary_on_headers('HTTP_X_REQUESTED_WITH')
     def post(self, request):

--- a/vis/apps/zendesk/views.py
+++ b/vis/apps/zendesk/views.py
@@ -21,7 +21,7 @@ class ZendeskView(View):
 
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
-        super(ZendeskView, self).dispatch(*args, **kwargs)
+        return super(ZendeskView, self).dispatch(*args, **kwargs)
 
     @vary_on_headers('HTTP_X_REQUESTED_WITH')
     def post(self, request):

--- a/vis/templates/includes/_feedback-form.jade
+++ b/vis/templates/includes/_feedback-form.jade
@@ -2,7 +2,6 @@
   details
     summary Is there anything wrong with this page?
     form.Feedback-form.js-Zendesk(action="{% url 'zendesk' %}", method="post", novalidate)
-      | {% csrf_token %}
       label.Feedback-label(for="comments")
         | Did you have a problem with this page? Tell us why.
         br


### PR DESCRIPTION
Disable CSRF on Zendesk endpoint

Since we want to put the entire site behind cloudfront (as otherwise we
can't really get the performance out of heroku/redis/dynos for some
reason) we can't really use CSRF like we normally would this end point.
But given it's a one off post this shouldn't really matter.

And we don't have to worry too much about this creating noise by making it easier to create tickets in Zendesk - if someone wanted to it wouldn't be all that hard to script it with a working CSRF token anyway.