### PR TITLE
Deprecate use of develop branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/deploy.sh
+++ b/deploy.sh
@@ -39,7 +39,7 @@ docker cp $CONTAINER_ID:/app/static ./static
 docker cp $CONTAINER_ID:/app/vis/assets ./vis/assets
 
 git add -f ./static ./vis/assets
-git cm -m 'deploy: add static assets'
+git commit -m 'deploy: add static assets'
 
 git push heroku-${ENVIRONMENT} HEAD:master -f
 $HEROKU_PATH config:add GIT_SHA=$GIT_SHA --app vis-${ENVIRONMENT}

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ fi
 
 ENVIRONMENT=$1
 GIT_SHA=$(git rev-parse HEAD)
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+BRANCH_NAME="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
 HEROKU_PATH="${HEROKU_PATH:-$(which heroku)}"
 
 # Check we're deploying the right branch to the right environment

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 if [ $# -ne 1 ]; then
   >&2 echo "Usage: ./deploy.sh environment"

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,6 +8,7 @@ fi
 ENVIRONMENT=$1
 GIT_SHA=$(git rev-parse HEAD)
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+HEROKU_PATH="${HEROKU_PATH:-$(which heroku)}"
 
 # Check we're deploying the right branch to the right environment
 if [ "$ENVIRONMENT" = "staging" ]; then
@@ -41,6 +42,6 @@ git add -f ./static ./vis/assets
 git cm -m 'deploy: add static assets'
 
 git push heroku-${ENVIRONMENT} HEAD:master -f
-heroku config:add GIT_SHA=$GIT_SHA --app vis-${ENVIRONMENT}
-heroku config:add DEPLOY_DATETIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --app vis-${ENVIRONMENT}
+$HEROKU_PATH config:add GIT_SHA=$GIT_SHA --app vis-${ENVIRONMENT}
+$HEROKU_PATH config:add DEPLOY_DATETIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --app vis-${ENVIRONMENT}
 git reset --hard HEAD^

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 1 ]; then
+  >&2 echo "Usage: ./deploy.sh environment"
+  exit 1
+fi
+
+ENVIRONMENT=$1
+GIT_SHA=$(git rev-parse HEAD)
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# Check we're deploying the right branch to the right environment
+if [ "$ENVIRONMENT" = "staging" ]; then
+  if [ "$BRANCH_NAME" != "develop" ]; then
+    >&2 echo "Can only deploy 'develop' to staging, you are on '${BRANCH_NAME}'"
+    exit 1
+  fi
+elif [ "$ENVIRONMENT" = "prod" ]; then
+  if [ "$BRANCH_NAME" != "master" ]; then
+    >&2 echo "Can only deploy 'master' to prod, you are on '${BRANCH_NAME}'"
+    exit 1
+  fi
+else
+  >&2 echo "Unknown environment '${ENVIRONMENT}'. Can be prod or staging."
+  exit 1
+fi
+
+# Check we have heroku remotes set up correctly
+if ! git remote | grep "^heroku-$ENVIRONMENT$" > /dev/null; then
+  >&2 echo "Heroku remote not found; expecting heroku-${ENVIRONMENT}"
+  exit 1
+fi
+
+docker build -t moj-vis .
+CONTAINER_ID=$(docker run -d moj-vis)
+
+docker cp $CONTAINER_ID:/app/static ./static
+docker cp $CONTAINER_ID:/app/vis/assets ./vis/assets
+
+git add -f ./static ./vis/assets
+git cm -m 'deploy: add static assets'
+
+git push heroku-${ENVIRONMENT} HEAD:master -f
+heroku config:add GIT_SHA=$GIT_SHA --app vis-${ENVIRONMENT}
+heroku config:add DEPLOY_DATETIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --app vis-${ENVIRONMENT}
+git reset --hard HEAD^

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [ $# -ne 1 ]; then
   >&2 echo "Usage: ./deploy.sh environment"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,9 @@ django:
     - POSTGRES_PASSWORD=password
     - POSTGRES_PORT=5432
     - POSTGRES_DB=vis
-    - DEBUG=True
-  command: ./manage.py runserver 0.0.0.0:8000 --settings=vis.settings.base
-  volumes:
-    - .:/app
+    - DOCKER_STATE=create
+    - DJANGO_SETTINGS_MODULE=vis.settings.base
+    - DJANGO_DEBUG=False
 postgres:
   image: postgres:9.4
   environment:

--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
     "merge-stream": "^0.1.7",
     "mkdirp": "^0.5.0",
     "require-dir": "0.1.0",
-    "run-sequence": "0.3.6",
+    "run-sequence": "0.3.7",
     "templatizer": "^1.2.1",
     "yargs": "3.0.4",
-    "yuglify": "0.1.4",
-
-    "chalk": "1.1.3"
+    "yuglify": "0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "run-sequence": "0.3.6",
     "templatizer": "^1.2.1",
     "yargs": "3.0.4",
-    "yuglify": "0.1.4"
+    "yuglify": "0.1.4",
+
+    "chalk": "1.1.3"
   }
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,8 @@ requests==2.5.1
 dj-database-url==0.3.0
 pyjade==3.0.0
 wagtail==0.8.5
-django-autoslug==1.7.2
 waitress==0.8.9
+django-autoslug==1.7.2
 django-redis-cache==0.13.0
 redis==2.10.3
 newrelic==2.50.0.39
@@ -18,7 +18,6 @@ django-secure==1.0.1
 geopy==1.9.1
 django-localflavor==1.1
 boto==2.38.0
-django-compressor>=1.4,<2.0 
+django-compressor>=1.4,<2.0
 django-modelcluster==1.1
-
-gunicorn==19.6.0
+whitenoise==3.3.0

--- a/run.sh
+++ b/run.sh
@@ -15,4 +15,4 @@ migrate)
     ;;
 esac
 
-gunicorn vis.wsgi --bind=0.0.0.0:8000
+${*:-waitress-serve --port=8000 vis.wsgi:application}

--- a/vis/apps/core/storage.py
+++ b/vis/apps/core/storage.py
@@ -1,4 +1,5 @@
 import json
+import os
 from urlparse import urldefrag, urlsplit, urlunsplit, unquote
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage, \
     HashedFilesMixin
@@ -8,7 +9,7 @@ from collections import OrderedDict
 
 class GulpManifestStaticFilesStorage(ManifestStaticFilesStorage):
 
-    manifest_name = settings.PROJECT_DIR + 'static/manifest.json'
+    manifest_name = os.path.join(settings.PROJECT_DIR, 'static/manifest.json')
 
     def post_process(self, *args, **kwargs):
         return []

--- a/vis/settings/base.py
+++ b/vis/settings/base.py
@@ -15,7 +15,7 @@ import dj_database_url
 
 # PATH vars
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-PROJECT_DIR = os.path.join(BASE_DIR, '../')
+PROJECT_DIR = os.path.dirname(BASE_DIR)
 sys.path.insert(0, os.path.join(PROJECT_DIR, 'vis/apps'))
 
 
@@ -26,11 +26,10 @@ sys.path.insert(0, os.path.join(PROJECT_DIR, 'vis/apps'))
 SECRET_KEY = 'dn@b!u!a^)g&61d^ec2!+fi$9g@%7^kh*@b$vby2^l+ra_ut0%'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'True') == 'True'
+TEMPLATE_DEBUG = DEBUG
 
-TEMPLATE_DEBUG = True
-
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 SITE_ID = 1
 
@@ -83,6 +82,8 @@ MIDDLEWARE_CLASSES = (
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
     'core.middleware.MaxAgeMiddleware',
+
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -102,7 +103,7 @@ TEMPLATE_LOADERS = (
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'assets-src/vendor'),
-    os.path.join(PROJECT_DIR, 'vis/assets'),
+    os.path.join(BASE_DIR, 'assets'),
 )
 
 STATICFILES_FINDERS = (
@@ -115,10 +116,6 @@ STATICFILES_FINDERS = (
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
 )
-
-
-STATIC_ROOT = os.path.join(PROJECT_DIR, 'static')
-
 
 ROOT_URLCONF = 'vis.urls'
 
@@ -165,7 +162,15 @@ CACHE_CONTROL_MAX_AGE = 0
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(PROJECT_DIR, 'static')
+STATIC_URL = os.environ.get('STATIC_URL', '/static/')
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = True
+
+PIPELINE_COMPILERS = ()
+PIPELINE_ENABLED = True
 
 MARKDOWN_PROTECT_PREVIEW = True
 
@@ -202,6 +207,10 @@ ZENDESK_CUSTOM_FIELD_SERVICE_ID = os.environ.get('ZENDESK_CUSTOM_FIELD_SERVICE_I
 ZENDESK_API_ENDPOINT = os.environ.get('ZENDESK_API_ENDPOINT', 'https://ministryofjustice.zendesk.com/api/v2/')
 
 
+S3_ACCESS_KEY_ID = os.environ.get('S3_ACCESS_KEY_ID')
+S3_SECRET_ACCESS_KEY_ID = os.environ.get('S3_SECRET_ACCESS_KEY_ID')
+S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME')
+
 # URL2PNG
 
 URL2PNG_API_KEY = os.environ.get('URL2PNG_API_KEY', '')
@@ -218,6 +227,35 @@ EXPORT_EMAIL_BODY = 'Find attached the VIS website.'
 EXPORT_RECIPIENTS = []
 
 GA_ID = os.environ.get('GA_ID', '')
+
+# LOGGING
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'stream': sys.stdout,
+            }
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+        'propagate': True,
+        },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': True,
+            'level': 'DEBUG',
+            },
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+            },
+    }
+}
 
 
 try:

--- a/vis/settings/heroku.py
+++ b/vis/settings/heroku.py
@@ -11,20 +11,8 @@ if DJ_DATABASE_URL:
 
 SECRET_KEY = os.environ.get('SECRET_KEY', '<not-used>')
 
-PIPELINE_COMPILERS = ()
-PIPELINE_ENABLED = True
-
-ALLOWED_HOSTS = ['*']
-
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
-
-STATICFILES_STORAGE = 'core.storage.GulpManifestStaticFilesStorage'
-
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
-
-STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 
 SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -36,10 +24,6 @@ SECURE_HSTS_SECONDS = 31536000
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_FRAME_DENY = True
 
-
-S3_ACCESS_KEY_ID = os.environ.get('S3_ACCESS_KEY_ID')
-S3_SECRET_ACCESS_KEY_ID = os.environ.get('S3_SECRET_ACCESS_KEY_ID')
-S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME')
 
 # REDIS
 if 'REDISTOGO_URL' in os.environ:
@@ -75,33 +59,3 @@ INSTALLED_APPS = INSTALLED_APPS + (
 EXPORT_RECIPIENTS = os.environ.get('EXPORT_RECIPIENTS', '').split(',')
 
 CACHE_CONTROL_MAX_AGE = 60*60
-
-
-# LOGGING
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': True,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'stream': sys.stdout,
-            }
-    },
-    'root': {
-        'handlers': ['console'],
-        'level': 'DEBUG',
-        'propagate': True,
-        },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'propagate': True,
-            'level': 'DEBUG',
-            },
-        'django.request': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': True,
-            },
-    }
-}


### PR DESCRIPTION
This brings in recent changes from the develop branch into the master branch so that we can deprecate the use of the develop branch. All other apps have a single merging branch, master.