### PR TITLE
Update gulp dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "merge-stream": "^0.1.7",
     "mkdirp": "^0.5.0",
     "require-dir": "0.1.0",
-    "run-sequence": "0.3.7",
+    "run-sequence": "2.2.1",
     "templatizer": "^1.2.1",
     "yargs": "3.0.4",
     "yuglify": "0.1.4"


### PR DESCRIPTION
This change fixes an issue with an older version of run-sequence
preventing the build from completing.