### PR TITLE
Stop deploying app using Circle CI

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,0 @@
-https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/r4vi/heroku-buildpack-nodejs
-https://github.com/heroku/heroku-buildpack-python.git

--- a/app.json
+++ b/app.json
@@ -3,8 +3,15 @@
   "description": "The UK's VIS website",
   "repository": "https://github.com/ministryofjustice/vis",
   "success_url": "/admin/",
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/python"
+    }
+  ],
   "env": {
-    "BUILDPACK_URL": "https://github.com/ddollar/heroku-buildpack-multi.git",
     "DJANGO_SETTINGS_MODULE": {
       "required": true,
       "description": "the settings file you'd like to use. In most cases just set this to vis.settings.heroku",

--- a/circle.yml
+++ b/circle.yml
@@ -1,47 +1,6 @@
 machine:
   environment:
     DJANGO_SETTINGS_MODULE: vis.settings.heroku
-    GIT_COMMITTER_NAME: circleci
-    GIT_AUTHOR_NAME: circleci
-    GIT_AUTHOR_EMAIL: circleci@example.com
-  post:
-    - git config --global user.email "circleci@exmaple.com"
-    - git config --global user.name "circleci"
-
-general:
-  branches:
-    only:
-    - master
-    - develop
-
-dependencies:
-  post:
-    - bower install
-
 test:
-  pre:
-    - node_modules/.bin/gulp build:prod
-    - python manage.py collectstatic --noinput
   override:
     - python manage.py test
-  post:
-      - git add ./vis/assets/ ./static/ -f
-      - git commit -m "deploy"
-
-deployment:
-  staging:
-    branch: develop
-    commands:
-      - git push git@heroku.com:vis-staging.git HEAD:master -f
-      - heroku config:add GIT_SHA=$CIRCLE_SHA1 --app vis-staging
-      - heroku config:add DEPLOY_DATETIME=`date -Is` --app vis-staging
-      - heroku run python manage.py migrate --noinput --app vis-staging
-      - '[ $(curl -s -o /dev/null -w "%{http_code}" https://origin-staging.victimsinformationservice.org.uk/healthcheck.json) = 200 ]'
-  production:
-    branch: master
-    commands:
-      - git push git@heroku.com:vis-prod.git HEAD:master -f
-      - heroku config:add GIT_SHA=$CIRCLE_SHA1 --app vis-prod
-      - heroku config:add DEPLOY_DATETIME=`date -Is` --app vis-prod
-      - heroku run python manage.py migrate --noinput --app vis-prod
-      - '[ $(curl -s -o /dev/null -w "%{http_code}" https://origin.victimsinformationservice.org.uk/healthcheck.json) = 200 ]'

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,0 @@
-http_path = "/"
-css_dir = "vis/static/css"
-sass_dir = "vis/static/stylesheets"
-images_dir = "vis/static/images"
-
-output_style = :compact

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": {
     "type": "git"
   },
+  "scripts": {
+    "postinstall": "bower install",
+    "heroku-postbuild": "gulp build:prod"
+  },
   "dependencies": {
     "bower": "^1.3.12",
     "browser-sync": "2.1.6",


### PR DESCRIPTION
This set of changes moves away from Circle CI deploying the app and makes use of Heroku Github link to deploy the app automatically from a branch.

See breakdown of commits for more details.