### PR TITLE
Use Heroku date/git hash environment variables

### DIFF
--- a/vis/apps/core/views.py
+++ b/vis/apps/core/views.py
@@ -20,8 +20,8 @@ REQUEST_TIMEOUT = 10
 
 def ping(request):
     return JsonResponse({
-        "commit_id": os.environ.get('GIT_SHA', ''),
-        "build_date": os.environ.get('DEPLOY_DATETIME', '')
+        "commit_id": os.environ.get('HEROKU_SLUG_COMMIT', ''),
+        "build_date": os.environ.get('HEROKU_RELEASE_CREATED_AT', '')
     })
 
 


### PR DESCRIPTION
Stop using auto created environment variables and use the ones that
Heroku provides