### PR TITLE
Update lodash to latest minor version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "fira": "~0.1.0",
-    "lodash": "~3.1.0",
+    "lodash": "~3.10.1",
     "jquery": "~1.11.2",
     "html5shiv": "~3.7.2",
     "jquery-details": "~0.1.0",


### PR DESCRIPTION
The current version of lodash has a security vulnerability. This change
updates version 3 to the latest minor version (3.10.1) to fix this.