### PR TITLE
Replace prime symbols with apostrophes

### DIFF
--- a/vis/templates/base.jade
+++ b/vis/templates/base.jade
@@ -21,7 +21,7 @@ html(lang="en", class="{% block html_class %}{% endblock %}")
           ga('set', 'page', page);
         }
         ga('send', 'pageview');
-    title {% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %} - Victims' Information Service
+    title {% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %} - Victims’ Information Service
     script(type="text/javascript")
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     <!--[if gt IE 8]><!--><link href="{% staticmin 'stylesheets/vis.css' %}" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/vis/templates/includes/_feedback-form.jade
+++ b/vis/templates/includes/_feedback-form.jade
@@ -6,6 +6,6 @@
       label.Feedback-label(for="comments")
         | Did you have a problem with this page? Tell us why.
         br
-        | Please don't include any personal information, eg your email address.
+        | Please don’t include any personal information, eg your email address.
       textarea.Feedback-textarea(cols="10", rows="3", id="comments", name="comments", required)
       button.Button.Feedback-submit(type="submit") Send feedback

--- a/vis/templates/includes/_footer.jade
+++ b/vis/templates/includes/_footer.jade
@@ -9,8 +9,8 @@ footer.SiteFooter(role="contentinfo")
           p
             | For information or for help with this site call&nbsp;
             strong.SiteFooter-contactNum 0808 168 9293
-          p.SiteFooter-contactTerms It's free from a landline, but you may be charged if you call from a mobile
-        h2.SiteFooter-contentTitle About Victims' Information Service
+          p.SiteFooter-contactTerms It’s free from a landline, but you may be charged if you call from a mobile
+        h2.SiteFooter-contentTitle About Victims’ Information Service
         p='about'|dynamic_content
         if maintenance != True
           nav

--- a/vis/templates/includes/_local-search.jade
+++ b/vis/templates/includes/_local-search.jade
@@ -1,7 +1,7 @@
 form.SearchForm(action="/police/search/", method="get", name=name, class="js-PCCSearch{% if modifier %} SearchForm--{{ modifier }}{% endif %}")
   label(for="q--{{ name }}")
     span.SearchForm-heading Find local help and support
-    span.SearchForm-subHeading If you've been a victim of crime, your local support team can help.
+    span.SearchForm-subHeading If you’ve been a victim of crime, your local support team can help.
     span.SearchForm-wrap
       span.SearchForm-labelText Enter your postcode
       input.SearchForm-query(name="q", id="q--{{ name }}", placeholder="Enter your postcode", type="text")

--- a/vis/templates/includes/_security-banner.jade
+++ b/vis/templates/includes/_security-banner.jade
@@ -1,6 +1,6 @@
 - load wagtailcore_tags
 section.SecurityBanner
-  h1.SecurityBanner-heading If you're worried about your safety online
+  h1.SecurityBanner-heading If you’re worried about your safety online
   p.SecurityBanner-content
-    a(href="{% slugurl 'online-safety' %}") Stop others seeing what you've done
+    a(href="{% slugurl 'online-safety' %}") Stop others seeing what you’ve done
   a.SecurityBanner-action.Button(href="https://www.google.com/") Leave this site

--- a/vis/templates/includes/_site-header.jade
+++ b/vis/templates/includes/_site-header.jade
@@ -5,9 +5,9 @@ header.SiteHeader(role="banner")
   .SiteHeader-inner
     h1.SiteHeader-title
       if maintenance != True
-        a(href='/') Victims' Information Service
+        a(href='/') Victims’ Information Service
       else
-        | Victims' Information Service
+        | Victims’ Information Service
     if maintenance != True
       a.SiteHeader-menuToggle.js-mobileMenuToggle(href="#", data-target=".SiteHeader-menu") Menu
         span

--- a/vis/templates/pages/pcc_page.jade
+++ b/vis/templates/pages/pcc_page.jade
@@ -49,7 +49,7 @@ block content
             h3 Find out about your case
             p
               a(href=self.trackmycrime_url, rel="external") Sign in to TrackMyCrime
-            p See what's happening with the investigation of your case.
+            p See what’s happening with the investigation of your case.
           h3 Find a court or tribunal
           p
             | Get addresses and other details by using the&nbsp;

--- a/vis/templates/pages/result_list.jade
+++ b/vis/templates/pages/result_list.jade
@@ -6,13 +6,13 @@ block content
     - include "includes/_breadcrumb.jade"
     header.PageHeader
       .PageHeader-row
-        h1.PageHeader-title Sorry, we don't recognise that location
+        h1.PageHeader-title Sorry, we don’t recognise that location
     .Content
       article.Article
         .Article-content
-          h3 If you're in England or Wales
+          h3 If you’re in England or Wales
           p Please try again. Or choose your area from the list below.
-          h3 If you're in another part of the UK or Channel Islands
+          h3 If you’re in another part of the UK or Channel Islands
           p You can find support in your area by following the links below.
           ul
             li
@@ -23,11 +23,11 @@ block content
               a(href="http://victimsupportjersey.co.uk", rel="external") Jersey
             li
               a(href="http://www.gov.gg/victims-witnesses", rel="external") Guernsey
-          h3 If you're overseas
+          h3 If you’re overseas
           p
-            | If the incident happened overseas and you're still abroad you can find advice on&nbsp;
+            | If the incident happened overseas and you’re still abroad you can find advice on&nbsp;
             a(href="https://www.gov.uk/victim-crime-abroad", rel="external") www.gov.uk
-          p If you want further help when you return home, you'll be supported by local services.
+          p If you want further help when you return home, you’ll be supported by local services.
           h3 Find your area in England or Wales
           - get_pcc_list as object_list
           - include "includes/_pcc-list.jade"


### PR DESCRIPTION
Previously within some content the prime symbol was being used
instead of an apostrophe. This change replaces the use of these
with the correct use of apostrophe.

[Article which explains their use](https://webdesignledger.com/common-typography-mistakes-apostrophes-versus-quotation-marks/)