### PR TITLE
Add missing semicolon

### DIFF
--- a/vis/assets-src/javascripts/modules/zendesk.js
+++ b/vis/assets-src/javascripts/modules/zendesk.js
@@ -53,7 +53,7 @@
     },
 
     isValid: function () {
-      var errors = []
+      var errors = [];
 
       if (this.$feedback.val() === '') {
         errors.push('Your comment cannot be blank');


### PR DESCRIPTION
During updates to the Zendesk JS module a semicolon was missed.

It won't break the module but it flags a warning in gulp. This change
fixes that linting area to remove the warning.