### PR TITLE
Change static call for images

### DIFF
--- a/vis/templates/base.jade
+++ b/vis/templates/base.jade
@@ -30,17 +30,17 @@ html(lang="en", class="{% block html_class %}{% endblock %}")
     <!--[if IE 8]><link href="{% staticmin 'stylesheets/vis-ie8.css' %}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if IE 9]><link href="{% staticmin 'stylesheets/vis-ie9.css' %}" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if lt IE 9]><script src="{% staticmin 'javascripts/ie.js' %}" type="text/javascript"></script><![endif]-->
-    link(rel="icon", sizes="180x180", href="{% staticmin 'images/icons/apple-touch-icon-180x180.png' %}")
-    link(rel="shortcut icon", href="{% staticmin 'images/icons/favicon.ico' %}", type="image/x-icon")
-    link(rel="apple-touch-icon", href="{% staticmin 'images/icons/apple-touch-icon.png' %}")
-    link(rel="apple-touch-icon", sizes="57x57", href="{% staticmin 'images/icons/apple-touch-icon-57x57.png' %}")
-    link(rel="apple-touch-icon", sizes="72x72", href="{% staticmin 'images/icons/apple-touch-icon-72x72.png' %}")
-    link(rel="apple-touch-icon", sizes="76x76", href="{% staticmin 'images/icons/apple-touch-icon-76x76.png' %}")
-    link(rel="apple-touch-icon", sizes="114x114", href="{% staticmin 'images/icons/apple-touch-icon-114x114.png' %}")
-    link(rel="apple-touch-icon", sizes="120x120", href="{% staticmin 'images/icons/apple-touch-icon-120x120.png' %}")
-    link(rel="apple-touch-icon", sizes="144x144", href="{% staticmin 'images/icons/apple-touch-icon-144x144.png' %}")
-    link(rel="apple-touch-icon", sizes="152x152", href="{% staticmin 'images/icons/apple-touch-icon-152x152.png' %}")
-    link(rel="apple-touch-icon", sizes="180x180", href="{% staticmin 'images/icons/apple-touch-icon-180x180.png' %}")
+    link(rel="icon", sizes="180x180", href="{% static 'images/icons/apple-touch-icon-180x180.png' %}")
+    link(rel="shortcut icon", href="{% static 'images/icons/favicon.ico' %}", type="image/x-icon")
+    link(rel="apple-touch-icon", href="{% static 'images/icons/apple-touch-icon.png' %}")
+    link(rel="apple-touch-icon", sizes="57x57", href="{% static 'images/icons/apple-touch-icon-57x57.png' %}")
+    link(rel="apple-touch-icon", sizes="72x72", href="{% static 'images/icons/apple-touch-icon-72x72.png' %}")
+    link(rel="apple-touch-icon", sizes="76x76", href="{% static 'images/icons/apple-touch-icon-76x76.png' %}")
+    link(rel="apple-touch-icon", sizes="114x114", href="{% static 'images/icons/apple-touch-icon-114x114.png' %}")
+    link(rel="apple-touch-icon", sizes="120x120", href="{% static 'images/icons/apple-touch-icon-120x120.png' %}")
+    link(rel="apple-touch-icon", sizes="144x144", href="{% static 'images/icons/apple-touch-icon-144x144.png' %}")
+    link(rel="apple-touch-icon", sizes="152x152", href="{% static 'images/icons/apple-touch-icon-152x152.png' %}")
+    link(rel="apple-touch-icon", sizes="180x180", href="{% static 'images/icons/apple-touch-icon-180x180.png' %}")
   body
     script(type="text/javascript")
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');


### PR DESCRIPTION
The icon images were using the `staticmin` method which was causing
the server to fall over when it couldn't find the `.min` version
of those files, which didn't exist.

This change uses the correct method to call those images.