### PR TITLE
Add an ID to each heading in content blocks

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,3 +21,5 @@ boto==2.38.0
 django-compressor>=1.4,<2.0
 django-modelcluster==1.1
 whitenoise==3.3.0
+beautifulsoup4==4.6.3
+html5lib==0.999

--- a/vis/apps/wagtailextra/templatetags/wagtailextra_tags.py
+++ b/vis/apps/wagtailextra/templatetags/wagtailextra_tags.py
@@ -1,4 +1,7 @@
 from django import template
+from django.utils.safestring import mark_safe
+from django.utils.text import slugify
+from bs4 import BeautifulSoup, Tag
 
 register = template.Library()
 
@@ -6,3 +9,20 @@ register = template.Library()
 @register.filter
 def is_pcc_user(user):
     return user.groups.filter(name='PCCEditor').exists()
+
+@register.filter
+def heading_ids(value):
+    """
+    Picks out the headings of a html string and assigns an ID
+    to each one so that they can be linked to using an anchor link
+    """
+    soup = BeautifulSoup(value, 'html5lib')
+    headings = soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+
+    for heading in headings:
+        heading['id'] = slugify(heading.getText())
+
+    soup.html.unwrap()
+    soup.head.unwrap()
+    soup.body.unwrap()
+    return mark_safe(soup.prettify())

--- a/vis/templates/pages/pcc_page.jade
+++ b/vis/templates/pages/pcc_page.jade
@@ -1,5 +1,5 @@
 - extends "base.jade"
-- load wagtailcore_tags helplines staticfiles pages_tags
+- load wagtailcore_tags wagtailextra_tags helplines staticfiles pages_tags
 
 block canonical
   //- Must have the ID canonical to update GA tracking page event
@@ -37,7 +37,7 @@ block content
               h3 Online information and help
               p
                 a(href=self.service_website_url, rel="external") Visit the #{self.service_name} website
-              #{self.content|richtext}
+              #{self.content|heading_ids|richtext}
             if self.service_phone_number
               h3 Talk to someone on the phone
               p Call #{self.service_phone_number}

--- a/vis/templates/pages/simple_page.jade
+++ b/vis/templates/pages/simple_page.jade
@@ -1,11 +1,11 @@
 - extends 'article.jade'
-- load glossary wagtailcore_tags
+- load glossary wagtailcore_tags wagtailextra_tags
 
 block article_title
   = self.title
 
 block article_content
-  #{self.content|richtext}
+  #{self.content|heading_ids|richtext}
 
 block article_aside
   - with self.link_items.all as l_items


### PR DESCRIPTION
This change allows anchor links to be created to specific bits of
content within a long page.

At the moment there is no way to generate a link to a manual anchor
within the richtext editor.

This slugifys the text of a heading and uses this value as the ID.