### PR TITLE
Spacing

### DIFF
--- a/vis/assets-src/stylesheets/_content.scss
+++ b/vis/assets-src/stylesheets/_content.scss
@@ -19,6 +19,12 @@ p, ul, ol {
   margin: 0 0 1.389em;
 }
 
+ul, ol {
+  li {
+    margin-bottom: 0.444em;
+  }
+}
+
 .Content {
   @extend %site-width-container;
 }

--- a/vis/assets-src/stylesheets/design-patterns/_sub-navigation.scss
+++ b/vis/assets-src/stylesheets/design-patterns/_sub-navigation.scss
@@ -1,10 +1,14 @@
 .SubNavigation-menu {
   @extend %contain-floats;
-  @include columns(2);
   @include font-18;
-  padding: 0 0 2.222em;
+  padding: 0 0 2.222em 1.25em;
   margin: 0;
-  list-style-position: inside;
+
+  @include media(desktop) {
+    @include columns(2);
+    list-style-position: inside;
+    padding-left: 0;
+  }
 }
 
 .SubNavigation-itemLink {

--- a/vis/assets-src/stylesheets/design-patterns/_sub-navigation.scss
+++ b/vis/assets-src/stylesheets/design-patterns/_sub-navigation.scss
@@ -7,10 +7,6 @@
   list-style-position: inside;
 }
 
-.SubNavigation-menuItem {
-  padding-bottom: 0.444em;
-}
-
 .SubNavigation-itemLink {
   .SubNavigation-menuItem--active & {
     color: $secondary-colour;


### PR DESCRIPTION
List items are currently very close together. If these are then a
list of links it creates very close click areas which are particularly
hard to click on mobile.

This change expands the space to make it easier to select a particular
item.

This also affects stacking of the sub navigation to display better on smaller devices.

## Before
![image](https://user-images.githubusercontent.com/3327997/48719782-2fc9f380-ec16-11e8-9f4a-d92ddbd41bb7.png)

## After
![image](https://user-images.githubusercontent.com/3327997/48719764-250f5e80-ec16-11e8-923f-55b201dc910b.png)
