### PR TITLE
Add identifier to search components

### DIFF
--- a/vis/templates/includes/_local-search.jade
+++ b/vis/templates/includes/_local-search.jade
@@ -1,4 +1,4 @@
-form.SearchForm(action="/police/search/", method="get", name=name, class="js-PCCSearch{% if modifier %} SearchForm--{{ modifier }}{% endif %}")
+form.SearchForm(action="/police/search/", method="get", id="{{ name }}-search", name=name, class="js-PCCSearch{% if modifier %} SearchForm--{{ modifier }}{% endif %}")
   label(for="q--{{ name }}")
     span.SearchForm-heading Find local help and support
     span.SearchForm-subHeading If you’ve been a victim of crime, your local support team can help.


### PR DESCRIPTION
This change adds an ID attribute to the search components so that they
can be specifically linked to using anchor links.