### PR TITLE
Fix erroneous spacing on links

### DIFF
--- a/vis/apps/wagtailextra/templatetags/wagtailextra_tags.py
+++ b/vis/apps/wagtailextra/templatetags/wagtailextra_tags.py
@@ -25,4 +25,4 @@ def heading_ids(value):
     soup.html.unwrap()
     soup.head.unwrap()
     soup.body.unwrap()
-    return mark_safe(soup.prettify())
+    return mark_safe(str(soup))

--- a/vis/templates/pages/pcc_page.jade
+++ b/vis/templates/pages/pcc_page.jade
@@ -37,7 +37,7 @@ block content
               h3 Online information and help
               p
                 a(href=self.service_website_url, rel="external") Visit the #{self.service_name} website
-              #{self.content|heading_ids|richtext}
+              #{self.content|richtext|heading_ids}
             if self.service_phone_number
               h3 Talk to someone on the phone
               p Call #{self.service_phone_number}

--- a/vis/templates/pages/simple_page.jade
+++ b/vis/templates/pages/simple_page.jade
@@ -5,7 +5,7 @@ block article_title
   = self.title
 
 block article_content
-  #{self.content|heading_ids|richtext}
+  #{self.content|richtext|heading_ids}
 
 block article_aside
   - with self.link_items.all as l_items


### PR DESCRIPTION
After adding the filter to add IDs to all headings it was adding
some extra whitespace to all links.

This was coming from Beautifulsoup's prettify method. Instead of
calling their builtin method we are now outputting it as a string in
the same format is was sent in.