### PR TITLE
Update gulp-iconfont tasks

### DIFF
--- a/tasks/iconfont.js
+++ b/tasks/iconfont.js
@@ -8,16 +8,18 @@
   var rename = require('gulp-rename');
 
   gulp.task('iconfont', function (cb) {
-    var fontName = 'vis-icons';
+    var runTimestamp = Math.round(Date.now() / 1000);
 
     return gulp.src(paths.icons)
       .pipe(iconfont({
-        fontName: fontName
+        fontName: 'vis-icons',
+        formats: ['ttf', 'eot', 'woff', 'svg'],
+        timestamp: runTimestamp,
       }))
-      .on('codepoints', function(codepoints) {
+      .on('glyphs', function(glyphs, options) {
         var templateOptions = {
-          glyphs: codepoints,
-          fontName: fontName,
+          glyphs: glyphs,
+          fontName: options.fontName,
           fontPath: '../fonts/',
           className: 'Icon'
         };
@@ -30,7 +32,7 @@
         // create template containing all fonts
         gulp.src(paths.src + 'templates/icon-template.html')
           .pipe(consolidate('lodash', templateOptions))
-          .pipe(rename({ basename: fontName }))
+          .pipe(rename({ basename: options.fontName }))
           .pipe(gulp.dest(paths.dest + 'fonts/'));
       })
       .pipe(gulp.dest(paths.dest + 'fonts/'));

--- a/vis/assets-src/templates/_icons.scss
+++ b/vis/assets-src/templates/_icons.scss
@@ -27,7 +27,7 @@
 }
 
 $icons: (
-  <%= glyphs.map(function(glyph){ return glyph.name + ': "' + '\\' + glyph.codepoint.toString(16).toUpperCase() + '"' }).join(',\n  ') %>
+  <%= glyphs.map(function(glyph){ return glyph.name + ': "' + '\\' + glyph.unicode[0].charCodeAt(0).toString(16).toUpperCase() + '"' }).join(',\n  ') %>
 );
 
 .<%= className %>,

--- a/vis/assets-src/templates/icon-template.html
+++ b/vis/assets-src/templates/icon-template.html
@@ -30,7 +30,7 @@
       <li>
         <i class="<%= className %> <%= className %>--<%= glyph.name %> <%= className %>--compact"></i>
         <span class="glyph-name"><%= glyph.name %></span>
-        <span class="glyph-codepoint"><%= glyph.codepoint.toString(16).toUpperCase() %></span>
+        <span class="glyph-codepoint"><%= glyph.unicode[0].charCodeAt(0).toString(16).toUpperCase() %></span>
       </li><% }); %>
     </ul>
   </body>


### PR DESCRIPTION
Since upgrading to a newer version of the gulp-iconfont package
the way the templates are generated has changed.

This change updates the task and templates to the new method.