### PR TITLE
Update jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6788,9 +6788,9 @@
       }
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "jquery.cookie": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-sass": "^3.2.1",
     "gulp-uglify": "^1.1.0",
     "html5shiv": "^3.7.3",
-    "jquery": "^1.12.4",
+    "jquery": "^3.3.1",
     "jquery.cookie": "^1.4.1",
     "jshint": "^2.9.6",
     "jshint-stylish": "^1.0.0",

--- a/vis/templates/base.jade
+++ b/vis/templates/base.jade
@@ -47,4 +47,4 @@ html(lang="en", class="{% block html_class %}{% endblock %}")
     - include "includes/_site-header.jade"
     block content
     - include "includes/_footer.jade"
-    script(src="{% staticmin 'javascripts/vis.js' %}")
+    <!--[if gte IE 9]><!--><script src="{% staticmin 'javascripts/vis.js' %}" type="text/javascript"></script><!--<![endif]-->


### PR DESCRIPTION
This site was still using jQuery 1 which flagged up some security
vulnerabilities around Cross Site Scripting:
https://nodesecurity.io/advisories/328

This updates to jQuery 3 which does drop some browser support.

However, after reviewing the analytics of the site this accounts for
a small proportion and JavaScript is not required for the site to
function so we can stop serving JavaScript to these older browsers.

## Internet Explorer analytics

Browsers using less than Internet Explorer 9 (which jQuery 3x no longer officially supports) currently accounts for ~3%.

![image](https://user-images.githubusercontent.com/3327997/49375381-04f29b80-f6fc-11e8-9869-f3de749d0c1f.png)
