### PR TITLE
Fix padding issue

### DIFF
--- a/vis/assets-src/stylesheets/design-patterns/_feedback.scss
+++ b/vis/assets-src/stylesheets/design-patterns/_feedback.scss
@@ -1,9 +1,12 @@
 .Feedback {
   @include grid-column( 1/1 );
-  border-top: 1px solid $dark-grey;
   display: block;
   margin-top: 2.778em;
-  padding: 2.778em 0 0;
+
+  details {
+    border-top: 1px solid $dark-grey;
+    padding-top: 2.778em;
+  }
 }
 .Feedback-label {
   @include font-18;


### PR DESCRIPTION
Some previous changes meant the border around the feedback component
didn't have the correct spacing between the edge of the container.

This change adjust the padding and margins to be in the correct place.

## Before
![before](https://user-images.githubusercontent.com/3327997/49445975-09d25080-f7cb-11e8-978e-b53d5800b056.png)

## After
![mobile](https://user-images.githubusercontent.com/3327997/49445984-0d65d780-f7cb-11e8-998e-580b3619a302.png)
