### PR TITLE
Adds watch and build:prod to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Gulp tasks are split into individual task files in `tasks/`.
 To watch assets and rebuild them after every change use this command:
 
 ```
-gulp watch
+npm run watch
 ```
 
 It will automatically run `gulp build:dev` and then create a [browsersync](http://www.browsersync.io/) server which will run at [http://localhost:3000](http://localhost:3000). By default it will proxy the django app from [http://localhost:8000](http://localhost:8000). To change the port add a `port` argument to the `watch` command, eg:

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "type": "git"
   },
   "scripts": {
-    "heroku-postbuild": "gulp build:prod",
-    "build:dev": "gulp build:dev"
+    "heroku-postbuild": "npm run build:prod",
+    "build:dev": "gulp build:dev",
+    "watch": "gulp build:dev watch",
+    "build:prod": "gulp build:prod"
   },
   "dependencies": {
     "del": "^1.1.1",


### PR DESCRIPTION
This adds in npm scripts for watch and buil so you can use gulp locally. It is similar to PR 166.