### PR TITLE
Fix hover state on mobile global nav

### DIFF
--- a/vis/assets-src/stylesheets/_header.scss
+++ b/vis/assets-src/stylesheets/_header.scss
@@ -173,19 +173,34 @@ a.SiteHeader-menuToggle {
   span {
     position: relative;
 
-    &:after {
-      content: "";
-      display: none;
-      position: absolute;
-      bottom: -5px;
-      height: 2px;
-      width: 100%;
-      background-color: $primary-colour;
+    @include media(desktop) {
+      &:after {
+        content: "";
+        display: none;
+        position: absolute;
+        bottom: -5px;
+        height: 2px;
+        width: 100%;
+        background-color: $primary-colour;
+      }
+    }
+  }
+
+  &.is-active span {
+    border-bottom: 2px solid $primary-colour;
+    padding-bottom: 3px;
+
+    @include media(desktop) {
+      border-bottom: 0;
+      display: block;
+      padding-bottom: 0;
     }
   }
 
   a:hover span:after,
   &.is-active span:after {
-    display: block;
+    @include media(desktop) {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
As we were using an after element to display the border it meant
that on mobile it required the link to be clicked twice due to
Apple devices first triggering the hover, then the click when using
:after elements.

We need to keep the desktop version using an :after element so that
we don't effect the height of the divider.