### PR TITLE
Update search form to show label

### DIFF
--- a/vis/assets-src/stylesheets/design-patterns/_search-form.scss
+++ b/vis/assets-src/stylesheets/design-patterns/_search-form.scss
@@ -5,14 +5,11 @@
   padding-left: 0;
   padding-right: 0;
   margin: 1.389em 0;
-  
+
   @include media(desktop) {
     margin: 0;
   }
-  
-}
-.SearchForm--compact {
-  margin-top: 0;
+
 }
 
 .SearchForm--hero {
@@ -28,12 +25,12 @@
   padding-top: 30.34%; /* (img-height / img-width * container-width) */
   /* (853 / 1280 * 100) */
   overflow: hidden;
-  
+
   @include device-pixel-ratio() {
     background-image: url('../images/homepage-background@2x.png');
     background-size: 100% auto;
   }
-  
+
   @include media(desktop) {
     border-bottom: 0;
     margin-bottom: 0;
@@ -68,7 +65,7 @@
   margin-bottom: 0;
 
   @include media(desktop) {
-    padding-bottom: 30px;
+    padding-bottom: 20px;
   }
 }
 .SearchForm-heading {
@@ -77,39 +74,18 @@
   @include media(desktop) {
     @include font-43(800);
   }
-
-  .SearchForm--compact & {
-    @include font-24(800);
-    color: $white;
-    padding-bottom: 10px;
-  }
 }
 .SearchForm-subHeading {
   @include font-18(500);
-
-  .SearchForm--compact & {
-    @extend .visuallyhidden;
-  }
 
   @include media(desktop) {
     padding-right: 60px;
   }
 }
 .SearchForm-labelText {
-  @extend .visuallyhidden;
-
-  @include ie-lte(9) {
-    @include font-18(500);
-    color: $primary-colour;
-    text-align: left;
-    position: relative;
-    left: auto;
-    display: block;
-
-    .SearchForm--compact & {
-      color: inherit;
-    }
-  }
+  @include font-18(500);
+  display: block;
+  margin-bottom: 8px;
 }
 .SearchForm-wrap {
   @extend %contain-floats;
@@ -131,12 +107,12 @@
       bottom: 0.639em;
     };
     float: left;
-    width: 220px;
+    width: 115px;
   }
 
   @include ie(7) {
     height: 30px;
-    width: 235px;
+    width: 130px;
   }
 
   &::-webkit-input-placeholder {

--- a/vis/templates/includes/_local-search.jade
+++ b/vis/templates/includes/_local-search.jade
@@ -7,9 +7,9 @@
       p.SearchForm-subHeading Your local support team will help you cope and recover after a crime.
     form(action="/find-local-support/", method="get", id="{{ name }}-search", name=name)
       label(for="q--{{ name }}")
-        span.SearchForm-labelText Enter your postcode
+        span.SearchForm-labelText Enter your full postcode
         span.SearchForm-wrap
-          input.SearchForm-query(name="q", id="q--{{ name }}", placeholder="Enter your postcode", type="text", value="#{ query if query else '' }")
+          input.SearchForm-query(name="q", id="q--{{ name }}", type="text", value="#{ query if query else '' }")
           button.Button.SearchForm-submit(type="submit")
             span.SearchForm-submitText Find
 

--- a/vis/templates/pcc_search.jade
+++ b/vis/templates/pcc_search.jade
@@ -26,7 +26,7 @@ block content
               block searchText
                 p There are support teams across England and Wales who help victims and witnesses recover after a crime.
                 p Local support is free, even if the crime hasn’t been reported to the police.
-              - include "includes/_local-search.jade" with modifier="compact" hideHeading="true" query=q name="landing-page"
+              - include "includes/_local-search.jade" with hideHeading="true" query=q name="landing-page"
               block nonEnglandWales
                 details.Details
                   summary


### PR DESCRIPTION
The search form was currently using a hidden label and showing the
label text within a placeholder. This means having a larger box
size which sometimes led to people entering things other than a
postcode.

This change moves the label outside and explains to enter the full
postcode as well as reducing the size of the box to suggest that
only a postcode should be entered.

## Todo

- [x] Check position of label on background image (may be worth waiting for #177 to be merged first)