### PR TITLE
If primary host exists, redirect to it

### DIFF
--- a/vis/apps/core/middleware.py
+++ b/vis/apps/core/middleware.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.shortcuts import redirect
 
 # default 30 days
 MAX_AGE = getattr(settings, 'CACHE_CONTROL_MAX_AGE', 2592000)
@@ -15,3 +16,8 @@ class MaxAgeMiddleware(object):
 
         response['Cache-Control'] = 'max-age=%d' % MAX_AGE
         return response
+
+class DomainRedirect(object):
+    def process_request(self, request):
+        if settings.PRIMARY_DOMAIN and (request.get_host() not in settings.PRIMARY_DOMAIN):
+            return redirect(settings.PRIMARY_DOMAIN + request.get_full_path(), True)

--- a/vis/settings/base.py
+++ b/vis/settings/base.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE_CLASSES = (
     'djangosecure.middleware.SecurityMiddleware',
+    'core.middleware.DomainRedirect',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -226,6 +227,8 @@ EXPORT_EMAIL_BODY = 'Find attached the VIS website.'
 EXPORT_RECIPIENTS = []
 
 GA_ID = os.environ.get('GA_ID', '')
+
+PRIMARY_DOMAIN = os.environ.get('PRIMARY_DOMAIN')
 
 # LOGGING
 LOGGING = {


### PR DESCRIPTION
As the service has moved domain we want to redirect all traffic
to the old domain to the new domain including the full URL path.

This change will redirect traffic if an environment variable has been
set with a primary domain if the requested domain doesn't match.