### PR TITLE
Create a fixture for PCC Search page

### DIFF
--- a/vis/apps/pages/fixtures/test_pages.json
+++ b/vis/apps/pages/fixtures/test_pages.json
@@ -1534,6 +1534,35 @@
 },
 {
     "fields": {
+        "locked": false,
+        "title": "Find local support",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "seo_title": "",
+        "latest_revision_created_at": "2018-12-11T16:02:24.157Z",
+        "depth": 3,
+        "search_description": "",
+        "content_type": [
+            "pages",
+            "pccsearchpage"
+        ],
+        "has_unpublished_changes": false,
+        "owner": [
+            "admin"
+        ],
+        "path": "000100010015",
+        "url_path": "/home/find-local-support/",
+        "expired": false,
+        "slug": "find-local-support",
+        "expire_at": null,
+        "go_live_at": null
+    },
+    "model": "wagtailcore.page",
+    "pk": 55
+},
+{
+    "fields": {
         "group": [
             "Moderators"
         ],
@@ -2277,5 +2306,11 @@
     },
     "model": "pages.pccpage",
     "pk": 54
+},
+{
+    "fields": {
+    },
+    "model": "pages.pccsearchpage",
+    "pk": 55
 }
 ]

--- a/vis/apps/pages/fixtures/test_pages.json
+++ b/vis/apps/pages/fixtures/test_pages.json
@@ -259,7 +259,7 @@
 {
     "fields": {
         "locked": true,
-        "title": "Police",
+        "title": "Area",
         "numchild": 43,
         "show_in_menus": false,
         "live": true,
@@ -276,9 +276,9 @@
             "admin"
         ],
         "path": "000100010008",
-        "url_path": "/home/police/",
+        "url_path": "/home/area/",
         "expired": false,
-        "slug": "police",
+        "slug": "area",
         "expire_at": null,
         "go_live_at": null
     },
@@ -305,7 +305,7 @@
             "admin"
         ],
         "path": "0001000100080001",
-        "url_path": "/home/police/avon-and-somerset/",
+        "url_path": "/home/area/avon-and-somerset/",
         "expired": false,
         "slug": "avon-and-somerset",
         "expire_at": null,
@@ -334,7 +334,7 @@
             "admin"
         ],
         "path": "0001000100080002",
-        "url_path": "/home/police/bedfordshire/",
+        "url_path": "/home/area/bedfordshire/",
         "expired": false,
         "slug": "bedfordshire",
         "expire_at": null,
@@ -363,7 +363,7 @@
             "admin"
         ],
         "path": "0001000100080003",
-        "url_path": "/home/police/cambridgeshire/",
+        "url_path": "/home/area/cambridgeshire/",
         "expired": false,
         "slug": "cambridgeshire",
         "expire_at": null,
@@ -392,7 +392,7 @@
             "admin"
         ],
         "path": "0001000100080004",
-        "url_path": "/home/police/cheshire/",
+        "url_path": "/home/area/cheshire/",
         "expired": false,
         "slug": "cheshire",
         "expire_at": null,
@@ -421,7 +421,7 @@
             "admin"
         ],
         "path": "0001000100080005",
-        "url_path": "/home/police/city-of-london/",
+        "url_path": "/home/area/city-of-london/",
         "expired": false,
         "slug": "city-of-london",
         "expire_at": null,
@@ -450,7 +450,7 @@
             "admin"
         ],
         "path": "0001000100080006",
-        "url_path": "/home/police/cleveland/",
+        "url_path": "/home/area/cleveland/",
         "expired": false,
         "slug": "cleveland",
         "expire_at": null,
@@ -479,7 +479,7 @@
             "admin"
         ],
         "path": "0001000100080007",
-        "url_path": "/home/police/cumbria/",
+        "url_path": "/home/area/cumbria/",
         "expired": false,
         "slug": "cumbria",
         "expire_at": null,
@@ -508,7 +508,7 @@
             "admin"
         ],
         "path": "0001000100080008",
-        "url_path": "/home/police/derbyshire/",
+        "url_path": "/home/area/derbyshire/",
         "expired": false,
         "slug": "derbyshire",
         "expire_at": null,
@@ -537,7 +537,7 @@
             "admin"
         ],
         "path": "0001000100080009",
-        "url_path": "/home/police/devon-and-cornwall/",
+        "url_path": "/home/area/devon-and-cornwall/",
         "expired": false,
         "slug": "devon-and-cornwall",
         "expire_at": null,
@@ -566,7 +566,7 @@
             "admin"
         ],
         "path": "0001000100080010",
-        "url_path": "/home/police/dorset/",
+        "url_path": "/home/area/dorset/",
         "expired": false,
         "slug": "dorset",
         "expire_at": null,
@@ -595,7 +595,7 @@
             "admin"
         ],
         "path": "0001000100080011",
-        "url_path": "/home/police/durham/",
+        "url_path": "/home/area/durham/",
         "expired": false,
         "slug": "durham",
         "expire_at": null,
@@ -624,7 +624,7 @@
             "admin"
         ],
         "path": "0001000100080012",
-        "url_path": "/home/police/dyfed-powys/",
+        "url_path": "/home/area/dyfed-powys/",
         "expired": false,
         "slug": "dyfed-powys",
         "expire_at": null,
@@ -653,7 +653,7 @@
             "admin"
         ],
         "path": "0001000100080013",
-        "url_path": "/home/police/essex/",
+        "url_path": "/home/area/essex/",
         "expired": false,
         "slug": "essex",
         "expire_at": null,
@@ -682,7 +682,7 @@
             "admin"
         ],
         "path": "0001000100080014",
-        "url_path": "/home/police/gloucestershire/",
+        "url_path": "/home/area/gloucestershire/",
         "expired": false,
         "slug": "gloucestershire",
         "expire_at": null,
@@ -711,7 +711,7 @@
             "admin"
         ],
         "path": "0001000100080015",
-        "url_path": "/home/police/greater-manchester/",
+        "url_path": "/home/area/greater-manchester/",
         "expired": false,
         "slug": "greater-manchester",
         "expire_at": null,
@@ -740,7 +740,7 @@
             "admin"
         ],
         "path": "0001000100080016",
-        "url_path": "/home/police/gwent/",
+        "url_path": "/home/area/gwent/",
         "expired": false,
         "slug": "gwent",
         "expire_at": null,
@@ -769,7 +769,7 @@
             "admin"
         ],
         "path": "0001000100080017",
-        "url_path": "/home/police/hampshire/",
+        "url_path": "/home/area/hampshire/",
         "expired": false,
         "slug": "hampshire",
         "expire_at": null,
@@ -798,7 +798,7 @@
             "admin"
         ],
         "path": "0001000100080018",
-        "url_path": "/home/police/hertfordshire/",
+        "url_path": "/home/area/hertfordshire/",
         "expired": false,
         "slug": "hertfordshire",
         "expire_at": null,
@@ -827,7 +827,7 @@
             "admin"
         ],
         "path": "0001000100080019",
-        "url_path": "/home/police/humberside/",
+        "url_path": "/home/area/humberside/",
         "expired": false,
         "slug": "humberside",
         "expire_at": null,
@@ -856,7 +856,7 @@
             "admin"
         ],
         "path": "0001000100080020",
-        "url_path": "/home/police/kent/",
+        "url_path": "/home/area/kent/",
         "expired": false,
         "slug": "kent",
         "expire_at": null,
@@ -885,7 +885,7 @@
             "admin"
         ],
         "path": "0001000100080021",
-        "url_path": "/home/police/lancashire/",
+        "url_path": "/home/area/lancashire/",
         "expired": false,
         "slug": "lancashire",
         "expire_at": null,
@@ -914,7 +914,7 @@
             "admin"
         ],
         "path": "0001000100080022",
-        "url_path": "/home/police/leicestershire/",
+        "url_path": "/home/area/leicestershire/",
         "expired": false,
         "slug": "leicestershire",
         "expire_at": null,
@@ -943,7 +943,7 @@
             "admin"
         ],
         "path": "0001000100080023",
-        "url_path": "/home/police/lincolnshire/",
+        "url_path": "/home/area/lincolnshire/",
         "expired": false,
         "slug": "lincolnshire",
         "expire_at": null,
@@ -972,7 +972,7 @@
             "admin"
         ],
         "path": "0001000100080024",
-        "url_path": "/home/police/merseyside/",
+        "url_path": "/home/area/merseyside/",
         "expired": false,
         "slug": "merseyside",
         "expire_at": null,
@@ -1001,7 +1001,7 @@
             "admin"
         ],
         "path": "0001000100080025",
-        "url_path": "/home/police/metropolitan/",
+        "url_path": "/home/area/metropolitan/",
         "expired": false,
         "slug": "metropolitan",
         "expire_at": null,
@@ -1030,7 +1030,7 @@
             "admin"
         ],
         "path": "0001000100080026",
-        "url_path": "/home/police/norfolk/",
+        "url_path": "/home/area/norfolk/",
         "expired": false,
         "slug": "norfolk",
         "expire_at": null,
@@ -1059,7 +1059,7 @@
             "admin"
         ],
         "path": "0001000100080027",
-        "url_path": "/home/police/north-wales/",
+        "url_path": "/home/area/north-wales/",
         "expired": false,
         "slug": "north-wales",
         "expire_at": null,
@@ -1088,7 +1088,7 @@
             "admin"
         ],
         "path": "0001000100080028",
-        "url_path": "/home/police/north-yorkshire/",
+        "url_path": "/home/area/north-yorkshire/",
         "expired": false,
         "slug": "north-yorkshire",
         "expire_at": null,
@@ -1117,7 +1117,7 @@
             "admin"
         ],
         "path": "0001000100080029",
-        "url_path": "/home/police/northamptonshire/",
+        "url_path": "/home/area/northamptonshire/",
         "expired": false,
         "slug": "northamptonshire",
         "expire_at": null,
@@ -1146,7 +1146,7 @@
             "admin"
         ],
         "path": "0001000100080030",
-        "url_path": "/home/police/northumbria/",
+        "url_path": "/home/area/northumbria/",
         "expired": false,
         "slug": "northumbria",
         "expire_at": null,
@@ -1175,7 +1175,7 @@
             "admin"
         ],
         "path": "0001000100080031",
-        "url_path": "/home/police/nottinghamshire/",
+        "url_path": "/home/area/nottinghamshire/",
         "expired": false,
         "slug": "nottinghamshire",
         "expire_at": null,
@@ -1204,7 +1204,7 @@
             "admin"
         ],
         "path": "0001000100080032",
-        "url_path": "/home/police/south-wales/",
+        "url_path": "/home/area/south-wales/",
         "expired": false,
         "slug": "south-wales",
         "expire_at": null,
@@ -1233,7 +1233,7 @@
             "admin"
         ],
         "path": "0001000100080033",
-        "url_path": "/home/police/south-yorkshire/",
+        "url_path": "/home/area/south-yorkshire/",
         "expired": false,
         "slug": "south-yorkshire",
         "expire_at": null,
@@ -1262,7 +1262,7 @@
             "admin"
         ],
         "path": "0001000100080034",
-        "url_path": "/home/police/staffordshire/",
+        "url_path": "/home/area/staffordshire/",
         "expired": false,
         "slug": "staffordshire",
         "expire_at": null,
@@ -1291,7 +1291,7 @@
             "admin"
         ],
         "path": "0001000100080035",
-        "url_path": "/home/police/suffolk/",
+        "url_path": "/home/area/suffolk/",
         "expired": false,
         "slug": "suffolk",
         "expire_at": null,
@@ -1320,7 +1320,7 @@
             "admin"
         ],
         "path": "0001000100080036",
-        "url_path": "/home/police/surrey/",
+        "url_path": "/home/area/surrey/",
         "expired": false,
         "slug": "surrey",
         "expire_at": null,
@@ -1349,7 +1349,7 @@
             "admin"
         ],
         "path": "0001000100080037",
-        "url_path": "/home/police/sussex/",
+        "url_path": "/home/area/sussex/",
         "expired": false,
         "slug": "sussex",
         "expire_at": null,
@@ -1378,7 +1378,7 @@
             "admin"
         ],
         "path": "0001000100080038",
-        "url_path": "/home/police/thames-valley/",
+        "url_path": "/home/area/thames-valley/",
         "expired": false,
         "slug": "thames-valley",
         "expire_at": null,
@@ -1407,7 +1407,7 @@
             "admin"
         ],
         "path": "0001000100080039",
-        "url_path": "/home/police/warwickshire/",
+        "url_path": "/home/area/warwickshire/",
         "expired": false,
         "slug": "warwickshire",
         "expire_at": null,
@@ -1436,7 +1436,7 @@
             "admin"
         ],
         "path": "0001000100080040",
-        "url_path": "/home/police/west-mercia/",
+        "url_path": "/home/area/west-mercia/",
         "expired": false,
         "slug": "west-mercia",
         "expire_at": null,
@@ -1465,7 +1465,7 @@
             "admin"
         ],
         "path": "0001000100080041",
-        "url_path": "/home/police/west-midlands/",
+        "url_path": "/home/area/west-midlands/",
         "expired": false,
         "slug": "west-midlands",
         "expire_at": null,
@@ -1494,7 +1494,7 @@
             "admin"
         ],
         "path": "0001000100080042",
-        "url_path": "/home/police/west-yorkshire/",
+        "url_path": "/home/area/west-yorkshire/",
         "expired": false,
         "slug": "west-yorkshire",
         "expire_at": null,
@@ -1523,7 +1523,7 @@
             "admin"
         ],
         "path": "0001000100080043",
-        "url_path": "/home/police/wiltshire/",
+        "url_path": "/home/area/wiltshire/",
         "expired": false,
         "slug": "wiltshire",
         "expire_at": null,


### PR DESCRIPTION
The new setup uses the find local support page as the path for
the search. This creates a fixture so that it will work locally
on initial setup and with heroku review apps.