### PR TITLE
Fix incorrect method call for feedback form

### DIFF
--- a/vis/assets-src/javascripts/modules/zendesk.js
+++ b/vis/assets-src/javascripts/modules/zendesk.js
@@ -26,7 +26,7 @@
     sendFeedback: function (data) {
       $.post(this.$form.attr('action'), data)
         .done(this.feedbackSuccess)
-        .error(this.feedbackFail);
+        .fail(this.feedbackFail.bind(this));
     },
 
     feedbackSuccess: function (resp) {


### PR DESCRIPTION
The error method wasn't being called correctly and was throwing
a JavaScript error when the form was submitted with an error.