### PR TITLE
Bind correct instance of this to feedback success method

### DIFF
--- a/vis/assets-src/javascripts/modules/zendesk.js
+++ b/vis/assets-src/javascripts/modules/zendesk.js
@@ -25,7 +25,7 @@
 
     sendFeedback: function (data) {
       $.post(this.$form.attr('action'), data)
-        .done(this.feedbackSuccess)
+        .done(this.feedbackSuccess.bind(this))
         .fail(this.feedbackFail.bind(this));
     },
 


### PR DESCRIPTION
The success method didn't have the correct context of this so
was throwing a JavaScript error when a successful piece
of feedback was sent.

This bind the zendesk object to `this` when it is called
from the `sendFeedback` method.