### PR TITLE
Migrates to gulp-clean-css from gulp-minify-css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4138,6 +4138,82 @@
         }
       }
     },
+    "gulp-clean-css": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-4.2.0.tgz",
+      "integrity": "sha512-r4zQsSOAK2UYUL/ipkAVCTRg/2CLZ2A+oPVORopBximRksJ6qy3EX1KGrIWT4ZrHxz3Hlobb1yyJtqiut7DNjA==",
+      "dev": true,
+      "requires": {
+        "clean-css": "4.2.1",
+        "plugin-error": "1.0.1",
+        "through2": "3.0.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+          "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          }
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "gulp-concat": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
@@ -4617,609 +4693,6 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "gulp-minify-css": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/gulp-minify-css/-/gulp-minify-css-0.5.1.tgz",
-      "integrity": "sha1-JTYjQE7+NUH7c/OyRHiA1NUnZ+Q=",
-      "requires": {
-        "clean-css": "^3.1.1",
-        "gulp-util": "^3.0.4",
-        "memory-cache": "0.1.0",
-        "through2": "^0.6.3",
-        "vinyl-bufferstream": "^1.0.1",
-        "vinyl-sourcemaps-apply": "^0.1.4"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        },
-        "clean-css": {
-          "version": "3.4.28",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
-          "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
-          "requires": {
-            "commander": "2.8.x",
-            "source-map": "0.4.x"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-              "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-              "requires": {
-                "graceful-readlink": ">= 1.0.0"
-              },
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-                }
-              }
-            }
-          }
-        },
-        "gulp-util": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-          "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-          "requires": {
-            "array-differ": "^1.0.0",
-            "array-uniq": "^1.0.2",
-            "beeper": "^1.0.0",
-            "chalk": "^1.0.0",
-            "dateformat": "^2.0.0",
-            "fancy-log": "^1.1.0",
-            "gulplog": "^1.0.0",
-            "has-gulplog": "^0.1.0",
-            "lodash._reescape": "^3.0.0",
-            "lodash._reevaluate": "^3.0.0",
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.template": "^3.0.0",
-            "minimist": "^1.1.0",
-            "multipipe": "^0.1.2",
-            "object-assign": "^3.0.0",
-            "replace-ext": "0.0.1",
-            "through2": "^2.0.0",
-            "vinyl": "^0.5.0"
-          },
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-              "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-            },
-            "array-uniq": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-            },
-            "beeper": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-              "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-              }
-            },
-            "dateformat": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-              "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-            },
-            "fancy-log": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-              "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-              "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "time-stamp": "^1.0.0"
-              },
-              "dependencies": {
-                "ansi-gray": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-                  "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-                  "requires": {
-                    "ansi-wrap": "0.1.0"
-                  },
-                  "dependencies": {
-                    "ansi-wrap": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-                      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-                    }
-                  }
-                },
-                "color-support": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-                  "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI="
-                },
-                "time-stamp": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-                  "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
-                }
-              }
-            },
-            "gulplog": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-              "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-              "requires": {
-                "glogg": "^1.0.0"
-              },
-              "dependencies": {
-                "glogg": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-                  "integrity": "sha1-3PdY5EeJzD89MsHzVio2duajSBA=",
-                  "requires": {
-                    "sparkles": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "sparkles": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-                      "integrity": "sha1-AI22XtzmxQ7sDF4ijhlFBh3QQ3w="
-                    }
-                  }
-                }
-              }
-            },
-            "has-gulplog": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-              "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-              "requires": {
-                "sparkles": "^1.0.0"
-              },
-              "dependencies": {
-                "sparkles": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-                  "integrity": "sha1-AI22XtzmxQ7sDF4ijhlFBh3QQ3w="
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-              "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-              "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-              "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-            },
-            "lodash.template": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-              "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-              "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
-              },
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                  "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-                  "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9",
-                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-                },
-                "lodash.escape": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-                  "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-                  "requires": {
-                    "lodash._root": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "lodash._root": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-                      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-                    }
-                  }
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-                  "requires": {
-                    "lodash._getnative": "^3.0.0",
-                    "lodash.isarguments": "^3.0.0",
-                    "lodash.isarray": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-                    }
-                  }
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-                  "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-                  "requires": {
-                    "lodash._reinterpolate": "^3.0.0",
-                    "lodash.escape": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-              "requires": {
-                "duplexer2": "0.0.2"
-              }
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-            },
-            "through2": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                    },
-                    "process-nextick-args": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.2",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-                    },
-                    "string_decoder": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-                      "requires": {
-                        "safe-buffer": "~5.1.0"
-                      }
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-              "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-              "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
-                "replace-ext": "0.0.1"
-              },
-              "dependencies": {
-                "clone": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                  "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-                }
-              }
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "lodash.templatesettings": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk="
-        },
-        "memory-cache": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.1.0.tgz",
-          "integrity": "sha1-FlfdPuJZ3I8hqRui79qW79U/NGk="
-        },
-        "minimist": {
-          "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-            }
-          }
-        },
-        "vinyl-bufferstream": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/vinyl-bufferstream/-/vinyl-bufferstream-1.0.1.tgz",
-          "integrity": "sha1-BTeGn1gO/6TKRay0dXnkuf5jCBo=",
-          "requires": {
-            "bufferstreams": "1.0.1"
-          },
-          "dependencies": {
-            "bufferstreams": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
-              "integrity": "sha1-z7GtlWjTujz+k1upq92VLeiKqyo=",
-              "requires": {
-                "readable-stream": "^1.0.33"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
-          "integrity": "sha1-xfy9Q+LyOEI8LcmL3db3m3K8NFs=",
-          "requires": {
-            "source-map": "^0.1.39"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.43",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-              "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-                }
-              }
-            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gulp-ignore": "^2.0.2",
     "gulp-imagemin": "^5.0.3",
     "gulp-jshint": "^2.1.0",
-    "gulp-minify-css": "^0.5.1",
     "gulp-print": "^1.1.0",
     "gulp-rename": "1.2.0",
     "gulp-rev-all": "^1.0.0",
@@ -46,6 +45,7 @@
   },
   "devDependencies": {
     "browser-sync": "^2.26.7",
+    "gulp-clean-css": "^4.2.0",
     "gulp-sass": "^4.0.2",
     "yargs": "3.0.4"
   }

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -8,7 +8,7 @@ var iconfont = require('gulp-iconfont');
 var consolidate = require('gulp-consolidate');
 var rename = require('gulp-rename');
 var ignore = require('gulp-ignore');
-var minifyCss = require('gulp-minify-css');
+var minifyCss = require('gulp-clean-css');
 var rename = require('gulp-rename');
 
 function buildIcons (cb) {
@@ -57,9 +57,7 @@ function minifyStyles () {
 
   return gulp.src(stylesDir + '**/*.css')
     .pipe(ignore.exclude('**/*.min.css'))
-    .pipe(minifyCss({
-      roundingPrecision: 3
-    }))
+    .pipe(minifyCss())
     .pipe(rename({
       suffix: '.min'
     }))


### PR DESCRIPTION
`gulp-minify-css` had a dependancy of `gulp-utils`, which is deprecated, and using an old version of `lodash`. This removes `gulp-minify-css` and replaces it with `gulp-clean-css`, which is the recommended alternative.